### PR TITLE
Speed Up Docker Builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore Github config.
+/.github
+
 # Ignore all environment files (except templates).
 /.env*
 !/.env*.erb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,19 @@ jobs:
           bundler-cache: true
       - run: bin/rails db:setup
       - run: bin/rspec --format RSpec::Github::Formatter
-  release:
-    name: "Release"
+  publish-docker:
+    name: "Publish Docker Image"
 #    if: github.ref == 'refs/heads/main'
     needs:
       - analyze
       - rspec
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - amd64
+          - arm64
     steps:
       - uses: actions/checkout@v4
       - name: Set Up QEMU
@@ -59,9 +65,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.platform }}-buildx-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-single-buildx
+            ${{ runner.os }}-${{ matrix.platform }}-buildx
 #      - name: Login to Docker Hub
 #        uses: docker/login-action@v3
 #        with:
@@ -73,7 +79,7 @@ jobs:
           context: .
           push: false
           tags: plainprogrammer/mtgcollector:latest
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.platform }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 #     Temp fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,13 @@ jobs:
     needs:
       - analyze
       - rspec
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        os:
+          - ubuntu-latest
+          - macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -63,9 +63,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-${{ matrix.platform }}-buildx-${{ github.sha }}
+          key: ${{ matrix.os }}-buildx-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.platform }}-buildx
+            ${{ matrix.os }}-buildx
 #      - name: Login to Docker Hub
 #        uses: docker/login-action@v3
 #        with:
@@ -77,7 +77,6 @@ jobs:
           context: .
           push: false
           tags: plainprogrammer/mtgcollector:latest
-          platforms: ${{ matrix.platform }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 #     Temp fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - amd64
-          - arm64
+          - linux/amd64
+          - linux/arm64
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -77,7 +77,7 @@ jobs:
           context: .
           push: false
           tags: plainprogrammer/mtgcollector:latest
-          platforms: linux/${{ matrix.platform }}
+          platforms: ${{ matrix.platform }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 #     Temp fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - run: bin/rspec --format RSpec::Github::Formatter
   release:
     name: "Release"
-    if: github.ref == 'refs/heads/main'
+#    if: github.ref == 'refs/heads/main'
     needs:
       - analyze
       - rspec
@@ -55,15 +55,15 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#      - name: Login to Docker Hub
+#        uses: docker/login-action@v3
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build & Push
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: false
           tags: plainprogrammer/mtgcollector:latest
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-single-buildx
 #      - name: Login to Docker Hub
 #        uses: docker/login-action@v3
 #        with:
@@ -67,3 +74,12 @@ jobs:
           push: false
           tags: plainprogrammer/mtgcollector:latest
           platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+#     Temp fix
+#     https://github.com/docker/build-push-action/issues/252
+#     https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - run: bin/rspec --format RSpec::Github::Formatter
   publish-docker:
     name: "Publish Docker Image"
-#    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     needs:
       - analyze
       - rspec
@@ -79,7 +79,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
+          push: true
           tags: plainprogrammer/mtgcollector:latest
           platforms: ${{ matrix.platform }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,6 @@ jobs:
           - arm64
     steps:
       - uses: actions/checkout@v4
-      - name: Set Up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Cache Docker layers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,24 +48,28 @@ jobs:
     needs:
       - analyze
       - rspec
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - uses: actions/checkout@v4
+      - name: Set Up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64,linux/amd64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ matrix.os }}-buildx-${{ github.sha }}
+          key: ${{ matrix.platform }}-buildx-${{ github.sha }}
           restore-keys: |
-            ${{ matrix.os }}-buildx
+            ${{ matrix.platform }}-buildx
 #      - name: Login to Docker Hub
 #        uses: docker/login-action@v3
 #        with:
@@ -77,6 +81,7 @@ jobs:
           context: .
           push: false
           tags: plainprogrammer/mtgcollector:latest
+          platforms: ${{ matrix.platform }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 #     Temp fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,11 @@ jobs:
           key: ${{ matrix.platform }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ matrix.platform }}-buildx
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v3
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build & Push
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
Run Docker builds for ARM64 and AMD64 platforms separately and add caching to speed up builds with unchanged layers.