### PR TITLE
Simplify Docker Build Steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - run: bin/rspec --format RSpec::Github::Formatter
   publish-docker:
     name: "Publish Docker Image"
-#    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     needs:
       - analyze
       - rspec
@@ -66,7 +66,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
+          push: true
           tags: plainprogrammer/mtgcollector:latest
           platforms: linux/amd64,linux/arm64
           cache-from: type=registry,ref=plainprogrammer/mtgcollector:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,17 +44,11 @@ jobs:
       - run: bin/rspec --format RSpec::Github::Formatter
   publish-docker:
     name: "Publish Docker Image"
-    if: github.ref == 'refs/heads/main'
+#    if: github.ref == 'refs/heads/main'
     needs:
       - analyze
       - rspec
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
     steps:
       - uses: actions/checkout@v4
       - name: Set Up QEMU
@@ -63,13 +57,6 @@ jobs:
           platforms: linux/arm64,linux/amd64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ matrix.platform }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ matrix.platform }}-buildx
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -79,15 +66,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: false
           tags: plainprogrammer/mtgcollector:latest
-          platforms: ${{ matrix.platform }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-#     Temp fix
-#     https://github.com/docker/build-push-action/issues/252
-#     https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=registry,ref=plainprogrammer/mtgcollector:latest
+          cache-to: type=inline


### PR DESCRIPTION
Go back to just one build step, instead of using matrix strategy. Use local cache for Docker from registry instead of manual caching.